### PR TITLE
Update Ge25519 v1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # ge25519-feedstock
+
+This library provides a native Python implementation of Ed25519 field elements and a number of operations over them.
+
+## Home:
+https://github.com/nthparty/ge25519
+
+## Upstream license:
+MIT
+
+## Feedstock license:
+BSD-3
+
+## Docs:
+https://github.com/nthparty/ge25519/blob/main/README.rst
+
+## Dev repo:
+https://github.com/nthparty/ge25519

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 upload_channels:
   - sfe1ed40
+
+channels:
+  - https://staging.continuum.io/prefect/fs/fe25519-feedstock/pr1/fb7225c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-  - https://staging.continuum.io/prefect/fs/fe25519-feedstock/pr1/fb7225c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "ge25519" %}
+{% set version = "1.5.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/ge25519-{{ version }}.tar.gz
+  sha256: 54a0cf89276e7d6c2b35c652453072154e181a826b9b8f130e6d67b785727250
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: True  # [py<38]
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - wheel
+    - pip
+  run:
+    - python
+    - fe25519 >=1.5,<2.dev0
+
+test:
+  imports:
+    - ge25519
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/nthparty/ge25519
+  summary: Pure-Python data structure for working with Ed25519 (and Ristretto) field elements and operations.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  description: |
+    This library provides a native Python implementation of Ed25519 field elements and a number of operations over them.
+  doc_url: https://github.com/nthparty/ge25519/blob/main/README.rst
+  dev_url: https://github.com/nthparty/ge25519
+
+extra:
+  recipe-maintainers:
+    - Arishamays1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ about:
   license_file: LICENSE
   description: |
     This library provides a native Python implementation of Ed25519 field elements and a number of operations over them.
-  doc_url: https://github.com/nthparty/ge25519/blob/main/README.rst
+  doc_url: https://ge25519.readthedocs.io
   dev_url: https://github.com/nthparty/ge25519
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/ge25519-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 54a0cf89276e7d6c2b35c652453072154e181a826b9b8f130e6d67b785727250
 
 build:


### PR DESCRIPTION
# ☆ Ge25519 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-3119)
[Upstream](https://github.com/nthparty/ge25519)
[Dependencies ](https://github.com/nthparty/ge25519/blob/1.5.1/pyproject.toml)

## Changes
- Newly rendered `meta.yaml` added to `recipe`
- Added information to `about` section
- Pinning and dependency amendments/formatting
- Added `abs.yaml`

## Relates to:
#https://github.com/AnacondaRecipes/oblivious-feedstock/pull/1
#https://github.com/AnacondaRecipes/fe25519-feedstock/pull/1